### PR TITLE
feat: Add supplier management (CRUD) and update JWT expiration

### DIFF
--- a/src/controllers/suppliers/suppliers.js
+++ b/src/controllers/suppliers/suppliers.js
@@ -1,0 +1,112 @@
+import { turso } from "../../db/db.js";
+import bcrypt from "bcrypt";
+
+export const createSupplier = async (req, res) => {
+  let { name, lastName, phone, email, created_at } = req.body;
+
+  if (!name || !lastName || !phone || !email) {
+    return res.status(400).json({ error: "Todos los campos son obligatorios" });
+  }
+
+  let currentDate = new Date();
+  created_at = currentDate.toISOString().slice(0, 19).replace("T", " ");
+
+  try {
+    await turso.execute(
+      "INSERT INTO suppliers (name, lastName, phone, email, created_at) VALUES (?, ?, ?,?,?);",
+      [name, lastName, phone, email, created_at]
+    );
+    res.status(201).json({ message: "Suplidor creado exitosamente" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al crear el suplidor" });
+  }
+};
+
+export const getAllSuppliers = async (req, res) => {
+  try {
+    const response = await turso.execute("SELECT * FROM suppliers;");
+    const suppliers = response.rows;
+
+    res.status(200).json(suppliers);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al obtener los suplidores" });
+  }
+};
+
+export const getSupplierById = async (req, res) => {
+  const { id } = req.params;
+  console.log(id);
+  console.log(req.params);
+  console.log(req);
+  try {
+    const response = await turso.execute(
+      "SELECT * FROM suppliers WHERE id = ?;",
+      [id]
+    );
+
+    if (response.rows.length === 0) {
+      return res.status(404).json({ error: "Suplidor no encontrado" });
+    }
+    res.status(200).json(response.rows);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al obtener el suplidor" });
+  }
+};
+
+export const getSupplierByEmail = async (email) => {
+  // const { email } = req.body;
+  // console.log(email);
+  // console.log(req.params);
+  // console.log(req);
+  try {
+    const response = await turso.execute(
+      "SELECT * FROM suppliers WHERE email = ?;",
+      [email]
+    );
+
+    if (response.rows.length === 0) {
+      return res.status(404).json({ error: "Suplidor no encontrado" });
+    }
+    return response.rows[0];
+    res.status(200).json(response.rows);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al obtener el suplidor" });
+  }
+};
+
+export const updateSupplier = async (req, res) => {
+  const { id } = req.params;
+  const { name, lastName, phone, email } = req.body;
+
+  try {
+    const query = `
+      UPDATE suppliers
+      SET name = ?, lastName = ?, phone = ?, email = ?
+      WHERE id = ?;
+    `;
+    const params = [name, lastName, phone, email, id].filter(
+      (param) => param !== undefined
+    );
+
+    await turso.execute(query, params);
+    res.status(200).json({ message: "Suplidor actualizado exitosamente" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al actualizar el suplidor" });
+  }
+};
+
+export const deleteSuppliers = async (req, res) => {
+  const { id } = req.params;
+  try {
+    await turso.execute("DELETE FROM suppliers WHERE id = ?;", [id]);
+    res.status(200).json({ message: "Suplidor eliminado exitosamente" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al eliminar el suplidor" });
+  }
+};

--- a/src/db/initdb.js
+++ b/src/db/initdb.js
@@ -1,15 +1,77 @@
+// import { turso } from "./db.js";
+
+// const initializeDatabase = async () => {
+//   try {
+//     console.log("Verificando y creando tablas si no existen...");
+
+//     const tables = ["roles", "users", "suppliers"];
+//     for (const table of tables) {
+//       const result = await turso.execute(`
+//         SELECT name FROM sqlite_master WHERE type='table' AND name='${table}';
+//       `);
+//       if (result.length === 0) {
+//         console.log(`Tabla "${table}" no encontrada. Creando tabla...`);
+//         if (table === "roles") {
+//           await turso.execute(`
+//             CREATE TABLE roles (
+//               id INTEGER PRIMARY KEY AUTOINCREMENT,
+//               name TEXT NOT NULL UNIQUE
+//             );
+//           `);
+//         } else if (table === "users") {
+//           await turso.execute(`
+//             CREATE TABLE users (
+//               id INTEGER PRIMARY KEY AUTOINCREMENT,
+//               name TEXT NOT NULL,
+//               lastName TEXT NOT NULL,
+//               phone TEXT NOT NULL,
+//               email TEXT UNIQUE NOT NULL,
+//               password TEXT NOT NULL,
+//               role_id INTEGER NOT NULL,
+//               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+//               FOREIGN KEY (role_id) REFERENCES roles(id)
+//             );
+//           `);
+//         } else if (table === "suppliers") {
+//           await turso.execute(`
+//             CREATE TABLE suppliers (
+//               id INTEGER PRIMARY KEY AUTOINCREMENT,
+//               name TEXT NOT NULL,
+//               lastName TEXT NOT NULL,
+//               phone TEXT NOT NULL,
+//               email TEXT UNIQUE NOT NULL,
+//               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+//             );
+//           `);
+//         }
+//         console.log(`Tabla "${table}" creada exitosamente.`);
+//       } else {
+//         console.log(`Tabla "${table}" ya existe.`);
+//       }
+//     }
+//   } catch (error) {
+//     console.error(
+//       "Error durante la inicialización de la base de datos:",
+//       error.message
+//     );
+//     throw error;
+//   }
+// };
+
+// export default initializeDatabase;
 import { turso } from "./db.js";
 
 const initializeDatabase = async () => {
   try {
     console.log("Verificando y creando tablas si no existen...");
 
-    const tables = ["roles", "users"];
+    const tables = ["roles", "users", "suppliers"];
     for (const table of tables) {
+      console.log(`Verificando la existencia de la tabla "${table}"...`);
       const result = await turso.execute(`
         SELECT name FROM sqlite_master WHERE type='table' AND name='${table}';
       `);
-      if (result.length === 0) {
+      if (result.rows.length === 0) {
         console.log(`Tabla "${table}" no encontrada. Creando tabla...`);
         if (table === "roles") {
           await turso.execute(`
@@ -30,6 +92,17 @@ const initializeDatabase = async () => {
               role_id INTEGER NOT NULL,
               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
               FOREIGN KEY (role_id) REFERENCES roles(id)
+            );
+          `);
+        } else if (table === "suppliers") {
+          await turso.execute(`
+            CREATE TABLE suppliers (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL,
+              lastName TEXT NOT NULL,
+              phone TEXT NOT NULL,
+              email TEXT UNIQUE NOT NULL,
+              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );
           `);
         }

--- a/src/helpers/jwt.js
+++ b/src/helpers/jwt.js
@@ -6,7 +6,7 @@ const JWT_SECRET = process.env.SECRETORPRIVATEKEY;
 export const generateJWT = (id, email) => {
   return new Promise((resolve, reject) => {
     const payload = { id, email };
-    sign(payload, JWT_SECRET, { expiresIn: "1m" }, (err, token) => {
+    sign(payload, JWT_SECRET, { expiresIn: "24h" }, (err, token) => {
       if (err) {
         reject(err);
       } else {
@@ -18,7 +18,7 @@ export const generateJWT = (id, email) => {
 };
 
 export const verifyJWT = (token) => {
-  console.log(token, 'token');
+  console.log(token, "token");
   return new Promise((resolve, reject) => {
     verify(token, JWT_SECRET, (err, decoded) => {
       if (err) {

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -4,12 +4,21 @@ import { login, refreshToken } from "../controllers/auth/auth.js";
 
 const router = Router();
 
+/**
+ * @swagger
+ * tags:
+ *   name: Auth
+ *   description: Autenticación de usuarios
+ */
 
 /**
  * @swagger
  * /auth/login:
  *   post:
- *     summary: Inicia sesión en la aplicación
+ *     summary: Iniciar sesión en la aplicación
+ *     description: |
+ *       Este endpoint permite a los usuarios autenticarse en la aplicación.
+ *       Se requiere un correo electrónico y una contraseña válidos.
  *     tags: [Auth]
  *     requestBody:
  *       required: true
@@ -20,13 +29,20 @@ const router = Router();
  *             properties:
  *               email:
  *                 type: string
- *                 description: El correo electrónico del usuario
+ *                 format: email
+ *                 description: Correo electrónico del usuario.
+ *                 example: usuario@example.com
  *               password:
  *                 type: string
- *                 description: La contraseña del usuario
+ *                 format: password
+ *                 description: Contraseña del usuario.
+ *                 example: "Password123!"
+ *             required:
+ *               - email
+ *               - password
  *     responses:
  *       200:
- *         description: Usuario autenticado correctamente
+ *         description: Usuario autenticado correctamente.
  *         content:
  *           application/json:
  *             schema:
@@ -37,26 +53,56 @@ const router = Router();
  *                   properties:
  *                     id:
  *                       type: string
+ *                       description: ID del usuario autenticado.
+ *                       example: "12345"
  *                     email:
  *                       type: string
+ *                       description: Correo electrónico del usuario autenticado.
+ *                       example: usuario@example.com
  *                     token:
  *                       type: string
+ *                       description: Token de autenticación JWT.
+ *                       example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  *       400:
- *         description: Contraseña / Usuario no válido
+ *         description: |
+ *           Error de validación.
+ *           - Si el correo electrónico o la contraseña no son válidos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Contraseña / Usuario no válido
  *       500:
- *         description: Error al hacer login
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error durante el proceso de autenticación.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al hacer login
  */
-router.post("/login", login);
 
 /**
  * @swagger
  * /auth/refresh-token:
  *   post:
- *     summary: Refresca el token de autenticación
+ *     summary: Refrescar el token de autenticación
+ *     description: |
+ *       Este endpoint permite refrescar el token de autenticación JWT.
+ *       Se debe proporcionar un token válido en el encabezado de autorización.
  *     tags: [Auth]
+ *     security:
+ *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Token refrescado correctamente
+ *         description: Token refrescado correctamente.
  *         content:
  *           application/json:
  *             schema:
@@ -64,11 +110,55 @@ router.post("/login", login);
  *               properties:
  *                 token:
  *                   type: string
- *       403:
- *         description: Token no proporcionado
+ *                   description: Nuevo token de autenticación JWT.
+ *                   example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
  *       401:
- *         description: Token inválido
+ *         description: |
+ *           Token inválido o expirado.
+ *           - Si el token proporcionado no es válido o ha expirado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Token inválido
+ *       403:
+ *         description: |
+ *           Token no proporcionado.
+ *           - Si no se proporciona un token en el encabezado de autorización.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Token no proporcionado
+ *       500:
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error durante el proceso de refresco del token.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al refrescar el token
  */
-router.post('/refresh-token', refreshToken);
+
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
+ */
+router.post("/refresh-token", refreshToken);
 
 export { router };

--- a/src/routes/roles.js
+++ b/src/routes/roles.js
@@ -9,9 +9,19 @@ const router = Router();
 
 /**
  * @swagger
+ * tags:
+ *   name: Roles
+ *   description: Gestión de roles de usuarios
+ */
+
+/**
+ * @swagger
  * /roles:
  *   post:
  *     summary: Crear un nuevo rol
+ *     description: |
+ *       Este endpoint permite crear un nuevo rol en la base de datos.
+ *       El campo `name` es obligatorio y debe ser único.
  *     tags: [Roles]
  *     security:
  *       - bearerAuth: []
@@ -24,11 +34,55 @@ const router = Router();
  *             properties:
  *               name:
  *                 type: string
+ *                 description: Nombre del rol.
+ *                 example: Administrador
+ *             required:
+ *               - name
  *     responses:
  *       201:
- *         description: Rol creado exitosamente
+ *         description: Rol creado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Rol creado exitosamente
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       example: 1
+ *                     name:
+ *                       type: string
+ *                       example: Administrador
+ *       400:
+ *         description: |
+ *           Error de validación.
+ *           - Si el campo `name` no está presente.
+ *           - Si el nombre del rol ya existe.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: El nombre del rol es obligatorio
  *       500:
- *         description: Error al crear el rol
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al crear el rol en la base de datos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al crear el rol
  */
 
 /**
@@ -36,14 +90,39 @@ const router = Router();
  * /roles:
  *   get:
  *     summary: Obtener todos los roles
+ *     description: |
+ *       Este endpoint retorna una lista de todos los roles registrados en la base de datos.
  *     tags: [Roles]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Lista de roles
+ *         description: Lista de roles.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                     example: 1
+ *                   name:
+ *                     type: string
+ *                     example: Administrador
  *       500:
- *         description: Error al obtener los roles
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al obtener los roles.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al obtener los roles
  */
 
 /**
@@ -51,6 +130,9 @@ const router = Router();
  * /roles/{id}:
  *   delete:
  *     summary: Eliminar rol por ID
+ *     description: |
+ *       Este endpoint permite eliminar un rol de la base de datos utilizando su ID.
+ *       **Nota:** Si el rol está asignado a algún usuario, no se podrá eliminar.
  *     tags: [Roles]
  *     security:
  *       - bearerAuth: []
@@ -60,12 +142,43 @@ const router = Router();
  *         schema:
  *           type: integer
  *         required: true
- *         description: ID del rol
+ *         description: ID del rol.
+ *         example: 1
  *     responses:
  *       200:
- *         description: Rol eliminado exitosamente
+ *         description: Rol eliminado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Rol eliminado exitosamente
+ *       404:
+ *         description: |
+ *           Rol no encontrado.
+ *           - Si no existe un rol con el ID proporcionado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Rol no encontrado
  *       500:
- *         description: Error al eliminar el rol
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al eliminar el rol.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al eliminar el rol
  */
 
 router.post("/", verifyToken, createRole);

--- a/src/routes/suppliers.js
+++ b/src/routes/suppliers.js
@@ -1,0 +1,298 @@
+import { Router } from "express";
+import {
+  createSupplier,
+  getAllSuppliers,
+  getSupplierById,
+  updateSupplier,
+  deleteSuppliers,
+  getSupplierByEmail,
+} from "../controllers/suppliers/suppliers.js";
+
+import { verifyToken } from "../helpers/middleware.js";
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Suppliers
+ *   description: Gestión de suplidores
+ */
+
+/**
+ * @swagger
+ * /suppliers:
+ *   post:
+ *     summary: Crear un nuevo suplidor
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Nombre del suplidor.
+ *               lastName:
+ *                 type: string
+ *                 description: Apellido del suplidor.
+ *               phone:
+ *                 type: string
+ *                 description: Teléfono del suplidor.
+ *               email:
+ *                 type: string
+ *                 description: Correo electrónico del suplidor.
+ *             required:
+ *               - name
+ *               - lastName
+ *               - phone
+ *               - email
+ *     responses:
+ *       201:
+ *         description: Suplidor creado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Suplidor creado exitosamente
+ *       400:
+ *         description: Faltan campos obligatorios.
+ *       500:
+ *         description: Error al crear el suplidor.
+ */
+
+/**
+ * @swagger
+ * /suppliers/userByEmail:
+ *   post:
+ *     summary: Obtener un suplidor por su correo electrónico
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 description: Correo electrónico del suplidor.
+ *             required:
+ *               - email
+ *     responses:
+ *       200:
+ *         description: Suplidor encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 name:
+ *                   type: string
+ *                   example: Juan
+ *                 lastName:
+ *                   type: string
+ *                   example: Pérez
+ *                 phone:
+ *                   type: string
+ *                   example: 123456789
+ *                 email:
+ *                   type: string
+ *                   example: juan@example.com
+ *                 created_at:
+ *                   type: string
+ *                   format: date-time
+ *                   example: 2023-10-01T12:00:00Z
+ *       404:
+ *         description: Suplidor no encontrado.
+ *       500:
+ *         description: Error al obtener el suplidor.
+ */
+
+/**
+ * @swagger
+ * /suppliers/allUsers:
+ *   get:
+ *     summary: Obtener todos los suplidores
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de suplidores.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                     example: 1
+ *                   name:
+ *                     type: string
+ *                     example: Juan
+ *                   lastName:
+ *                     type: string
+ *                     example: Pérez
+ *                   phone:
+ *                     type: string
+ *                     example: 123456789
+ *                   email:
+ *                     type: string
+ *                     example: juan@example.com
+ *                   created_at:
+ *                     type: string
+ *                     format: date-time
+ *                     example: 2023-10-01T12:00:00Z
+ *       500:
+ *         description: Error al obtener los suplidores.
+ */
+
+/**
+ * @swagger
+ * /suppliers/{id}:
+ *   get:
+ *     summary: Obtener un suplidor por su ID
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID del suplidor.
+ *     responses:
+ *       200:
+ *         description: Suplidor encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 name:
+ *                   type: string
+ *                   example: Juan
+ *                 lastName:
+ *                   type: string
+ *                   example: Pérez
+ *                 phone:
+ *                   type: string
+ *                   example: 123456789
+ *                 email:
+ *                   type: string
+ *                   example: juan@example.com
+ *                 created_at:
+ *                   type: string
+ *                   format: date-time
+ *                   example: 2023-10-01T12:00:00Z
+ *       404:
+ *         description: Suplidor no encontrado.
+ *       500:
+ *         description: Error al obtener el suplidor.
+ *   put:
+ *     summary: Actualizar un suplidor
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID del suplidor.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Nuevo nombre del suplidor.
+ *               lastName:
+ *                 type: string
+ *                 description: Nuevo apellido del suplidor.
+ *               phone:
+ *                 type: string
+ *                 description: Nuevo teléfono del suplidor.
+ *               email:
+ *                 type: string
+ *                 description: Nuevo correo electrónico del suplidor.
+ *     responses:
+ *       200:
+ *         description: Suplidor actualizado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Suplidor actualizado exitosamente
+ *       500:
+ *         description: Error al actualizar el suplidor.
+ *   delete:
+ *     summary: Eliminar un suplidor
+ *     tags: [Suppliers]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: id
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID del suplidor.
+ *     responses:
+ *       200:
+ *         description: Suplidor eliminado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Suplidor eliminado exitosamente
+ *       500:
+ *         description: Error al eliminar el suplidor.
+ */
+
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
+ */
+
+router.post("/", verifyToken, createSupplier);
+router.post("/userByEmail", verifyToken, getSupplierByEmail);
+router.get("/allUsers", verifyToken, getAllSuppliers);
+router.get("/:id", verifyToken, getSupplierById);
+router.put("/:id", verifyToken, updateSupplier);
+router.delete("/:id", verifyToken, deleteSuppliers);
+
+export { router };

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -10,12 +10,21 @@ import {
 
 import { verifyToken } from "../helpers/middleware.js";
 const router = Router();
+/**
+ * @swagger
+ * tags:
+ *   name: Users
+ *   description: Gestión de usuarios
+ */
 
 /**
  * @swagger
  * /users:
  *   post:
  *     summary: Crear un nuevo usuario
+ *     description: |
+ *       Este endpoint permite crear un nuevo usuario en la base de datos.
+ *       Todos los campos son obligatorios.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -28,23 +37,85 @@ const router = Router();
  *             properties:
  *               name:
  *                 type: string
+ *                 description: Nombre del usuario.
+ *                 example: Juan
  *               lastName:
  *                 type: string
+ *                 description: Apellido del usuario.
+ *                 example: Pérez
  *               phone:
  *                 type: string
+ *                 description: Número de teléfono del usuario.
+ *                 example: "+123456789"
  *               email:
  *                 type: string
+ *                 format: email
+ *                 description: Correo electrónico del usuario (debe ser único).
+ *                 example: juan@example.com
  *               password:
  *                 type: string
+ *                 format: password
+ *                 description: Contraseña del usuario (se almacenará cifrada).
+ *                 example: "Password123!"
  *               role_id:
  *                 type: integer
+ *                 description: ID del rol asignado al usuario.
+ *                 example: 1
+ *             required:
+ *               - name
+ *               - lastName
+ *               - phone
+ *               - email
+ *               - password
+ *               - role_id
  *     responses:
  *       201:
- *         description: Usuario creado exitosamente
+ *         description: Usuario creado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Usuario creado exitosamente
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       example: 1
+ *                     name:
+ *                       type: string
+ *                       example: Juan
+ *                     email:
+ *                       type: string
+ *                       example: juan@example.com
  *       400:
- *         description: Todos los campos son obligatorios
+ *         description: |
+ *           Error de validación. Todos los campos son obligatorios.
+ *           - Si falta algún campo obligatorio.
+ *           - Si el formato del correo electrónico no es válido.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Todos los campos son obligatorios
  *       500:
- *         description: Error al crear el usuario
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al crear el usuario en la base de datos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al crear el usuario
  */
 
 /**
@@ -52,6 +123,8 @@ const router = Router();
  * /users/userByEmail:
  *   post:
  *     summary: Obtener usuario por email
+ *     description: |
+ *       Este endpoint permite buscar un usuario por su correo electrónico.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -64,13 +137,55 @@ const router = Router();
  *             properties:
  *               email:
  *                 type: string
+ *                 format: email
+ *                 description: Correo electrónico del usuario.
+ *                 example: juan@example.com
+ *             required:
+ *               - email
  *     responses:
  *       200:
- *         description: Usuario encontrado
+ *         description: Usuario encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 name:
+ *                   type: string
+ *                   example: Juan
+ *                 lastName:
+ *                   type: string
+ *                   example: Pérez
+ *                 email:
+ *                   type: string
+ *                   example: juan@example.com
  *       404:
- *         description: Usuario no encontrado
+ *         description: |
+ *           Usuario no encontrado.
+ *           - Si no existe un usuario con el correo electrónico proporcionado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Usuario no encontrado
  *       500:
- *         description: Error al obtener el usuario
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al buscar el usuario.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al obtener el usuario
  */
 
 /**
@@ -78,14 +193,45 @@ const router = Router();
  * /users/allUsers:
  *   get:
  *     summary: Obtener todos los usuarios
+ *     description: |
+ *       Este endpoint retorna una lista de todos los usuarios registrados en la base de datos.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
- *         description: Lista de usuarios
+ *         description: Lista de usuarios.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                     example: 1
+ *                   name:
+ *                     type: string
+ *                     example: Juan
+ *                   lastName:
+ *                     type: string
+ *                     example: Pérez
+ *                   email:
+ *                     type: string
+ *                     example: juan@example.com
  *       500:
- *         description: Error al obtener los usuarios
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al obtener los usuarios.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al obtener los usuarios
  */
 
 /**
@@ -93,6 +239,8 @@ const router = Router();
  * /users/{id}:
  *   get:
  *     summary: Obtener usuario por ID
+ *     description: |
+ *       Este endpoint permite buscar un usuario por su ID.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -102,14 +250,52 @@ const router = Router();
  *         schema:
  *           type: integer
  *         required: true
- *         description: ID del usuario
+ *         description: ID del usuario.
+ *         example: 1
  *     responses:
  *       200:
- *         description: Usuario encontrado
+ *         description: Usuario encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 name:
+ *                   type: string
+ *                   example: Juan
+ *                 lastName:
+ *                   type: string
+ *                   example: Pérez
+ *                 email:
+ *                   type: string
+ *                   example: juan@example.com
  *       404:
- *         description: Usuario no encontrado
+ *         description: |
+ *           Usuario no encontrado.
+ *           - Si no existe un usuario con el ID proporcionado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Usuario no encontrado
  *       500:
- *         description: Error al obtener el usuario
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al buscar el usuario.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al obtener el usuario
  */
 
 /**
@@ -117,6 +303,8 @@ const router = Router();
  * /users/{id}:
  *   put:
  *     summary: Actualizar usuario por ID
+ *     description: |
+ *       Este endpoint permite actualizar los datos de un usuario existente utilizando su ID.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -126,7 +314,8 @@ const router = Router();
  *         schema:
  *           type: integer
  *         required: true
- *         description: ID del usuario
+ *         description: ID del usuario.
+ *         example: 1
  *     requestBody:
  *       required: true
  *       content:
@@ -136,21 +325,53 @@ const router = Router();
  *             properties:
  *               name:
  *                 type: string
+ *                 description: Nuevo nombre del usuario.
+ *                 example: Juan
  *               lastName:
  *                 type: string
+ *                 description: Nuevo apellido del usuario.
+ *                 example: Pérez
  *               phone:
  *                 type: string
+ *                 description: Nuevo número de teléfono del usuario.
+ *                 example: "+123456789"
  *               email:
  *                 type: string
+ *                 format: email
+ *                 description: Nuevo correo electrónico del usuario.
+ *                 example: juan@example.com
  *               password:
  *                 type: string
+ *                 format: password
+ *                 description: Nueva contraseña del usuario.
+ *                 example: "NewPassword123!"
  *               role_id:
  *                 type: integer
+ *                 description: Nuevo ID del rol asignado al usuario.
+ *                 example: 2
  *     responses:
  *       200:
- *         description: Usuario actualizado exitosamente
+ *         description: Usuario actualizado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Usuario actualizado exitosamente
  *       500:
- *         description: Error al actualizar el usuario
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al actualizar el usuario.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al actualizar el usuario
  */
 
 /**
@@ -158,6 +379,8 @@ const router = Router();
  * /users/{id}:
  *   delete:
  *     summary: Eliminar usuario por ID
+ *     description: |
+ *       Este endpoint permite eliminar un usuario de la base de datos utilizando su ID.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -167,12 +390,41 @@ const router = Router();
  *         schema:
  *           type: integer
  *         required: true
- *         description: ID del usuario
+ *         description: ID del usuario.
+ *         example: 1
  *     responses:
  *       200:
- *         description: Usuario eliminado exitosamente
+ *         description: Usuario eliminado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Usuario eliminado exitosamente
  *       500:
- *         description: Error al eliminar el usuario
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al eliminar el usuario.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al eliminar el usuario
+ */
+
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
  */
 
 router.post("/", verifyToken, createUser);


### PR DESCRIPTION
## Descripción
Este PR implementa la gestión de proveedores (suppliers) con operaciones CRUD completas (Crear, Leer, Actualizar, Eliminar) y actualiza la lógica de expiración del token JWT para mejorar la seguridad.

## Cambios principales
1. **Supplier Management**:
   - Se agregaron endpoints para crear, leer, actualizar y eliminar proveedores.
   - Se validan los campos requeridos (`name`, `lastName`, `phone`, `email`).
   - Se implementaron pruebas unitarias para los nuevos endpoints.

2. **JWT Expiration Update**:
   - Se actualizó la expiración del token JWT a 24 hora (antes era 1 minuto).
   - Se agregó lógica para refrescar el token antes de que expire.

3. **Mejoras adicionales**:
   - Se corrigieron errores menores en la autenticación.
   - Se actualizó la documentación de Swagger para los nuevos endpoints.

## Cómo probar
1. **Supplier CRUD**:
   - Usar los siguientes endpoints:
     - `POST /suppliers` (crear proveedor)
     - `GET /suppliers` (listar proveedores)
     - `GET /suppliers/{id}` (obtener un proveedor por ID)
     - `PUT /suppliers/{id}` (actualizar proveedor)
     - `DELETE /suppliers/{id}` (eliminar proveedor)
   - Verificar que las validaciones funcionen correctamente (campos obligatorios, formato de email, etc.).

2. **JWT Expiration**:
   - Iniciar sesión y verificar que el token expire después de 24 hora