### PR TITLE
feat: Add materials management with CRUD operations and database initialization

### DIFF
--- a/src/controllers/materiales/materials.js
+++ b/src/controllers/materiales/materials.js
@@ -1,1 +1,0 @@
-import { turso } from "../../db/db.js";

--- a/src/controllers/materials/materials.js
+++ b/src/controllers/materials/materials.js
@@ -1,0 +1,137 @@
+import { turso } from "../../db/db.js";
+
+export const createMaterials = async (req, res) => {
+  let {
+    name,
+    description,
+    isAvailable,
+    cost,
+    date,
+    supplier_id,
+    quantity,
+    quantityByUnit,
+    costByUnit,
+    created_at,
+  } = req.body;
+
+  if (
+    !name ||
+    !description ||
+    !isAvailable ||
+    !cost ||
+    !date ||
+    !supplier_id ||
+    !quantity ||
+    !quantityByUnit ||
+    !costByUnit
+  ) {
+    return res.status(400).json({ error: "Todos los campos son obligatorios" });
+  }
+
+  let currentDate = new Date();
+  created_at = currentDate.toISOString().slice(0, 19).replace("T", " ");
+
+  try {
+    await turso.execute(
+      "INSERT INTO materials (name, description, isAvailable, cost, date, supplier_id, quantity, quantityByUnit, costByUnit, created_at) VALUES (?,?,?,?,?,?,?,?,?,?);",
+      [
+        name,
+        description,
+        isAvailable,
+        cost,
+        date,
+        supplier_id,
+        quantity,
+        quantityByUnit,
+        costByUnit,
+        created_at,
+      ]
+    );
+    res.status(201).json({ message: "Material creado exitosamente" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al crear el material" });
+  }
+};
+
+export const getAllMaterials = async (req, res) => {
+  try {
+    const response = await turso.execute("SELECT * FROM materials;");
+    const materials = response.rows;
+
+    res.status(200).json(materials);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al obtener los materiales" });
+  }
+};
+
+export const getMaterialById = async (req, res) => {
+  const { id } = req.params;
+  console.log(id);
+  console.log(req.params);
+  console.log(req);
+  try {
+    const response = await turso.execute(
+      "SELECT * FROM materials WHERE id = ?;",
+      [id]
+    );
+
+    if (response.rows.length === 0) {
+      return res.status(404).json({ error: "Material no encontrado" });
+    }
+    res.status(200).json(response.rows);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al obtener el material" });
+  }
+};
+
+export const updateMaterial = async (req, res) => {
+  const { id } = req.params;
+  const {
+    name,
+    description,
+    isAvailable,
+    cost,
+    date,
+    supplier_id,
+    quantity,
+    quantityByUnit,
+    costByUnit,
+  } = req.body;
+
+  try {
+    await turso.execute(
+      `UPDATE materials SET name = ?, description = ?, isAvailable = ?, cost = ?, date = ?, supplier_id = ?, quantity = ?, quantityByUnit = ?, costByUnit = ? WHERE id = ?;`,
+      [
+        name,
+        description,
+        isAvailable,
+        cost,
+        date,
+        supplier_id,
+        quantity,
+        quantityByUnit,
+        costByUnit,
+        id,
+      ]
+    );
+    res.status(200).json({ message: "Material actualizado exitosamente" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al actualizar el material" });
+  }
+};
+
+export const deleteMaterial = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    await turso.execute("DELETE FROM materials WHERE id = ?;", [id]);
+    res.status(200).json({ message: "Material eliminado exitosamente" });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: "Error al eliminar el material" });
+  }
+};

--- a/src/db/initdb.js
+++ b/src/db/initdb.js
@@ -1,71 +1,10 @@
-// import { turso } from "./db.js";
-
-// const initializeDatabase = async () => {
-//   try {
-//     console.log("Verificando y creando tablas si no existen...");
-
-//     const tables = ["roles", "users", "suppliers"];
-//     for (const table of tables) {
-//       const result = await turso.execute(`
-//         SELECT name FROM sqlite_master WHERE type='table' AND name='${table}';
-//       `);
-//       if (result.length === 0) {
-//         console.log(`Tabla "${table}" no encontrada. Creando tabla...`);
-//         if (table === "roles") {
-//           await turso.execute(`
-//             CREATE TABLE roles (
-//               id INTEGER PRIMARY KEY AUTOINCREMENT,
-//               name TEXT NOT NULL UNIQUE
-//             );
-//           `);
-//         } else if (table === "users") {
-//           await turso.execute(`
-//             CREATE TABLE users (
-//               id INTEGER PRIMARY KEY AUTOINCREMENT,
-//               name TEXT NOT NULL,
-//               lastName TEXT NOT NULL,
-//               phone TEXT NOT NULL,
-//               email TEXT UNIQUE NOT NULL,
-//               password TEXT NOT NULL,
-//               role_id INTEGER NOT NULL,
-//               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-//               FOREIGN KEY (role_id) REFERENCES roles(id)
-//             );
-//           `);
-//         } else if (table === "suppliers") {
-//           await turso.execute(`
-//             CREATE TABLE suppliers (
-//               id INTEGER PRIMARY KEY AUTOINCREMENT,
-//               name TEXT NOT NULL,
-//               lastName TEXT NOT NULL,
-//               phone TEXT NOT NULL,
-//               email TEXT UNIQUE NOT NULL,
-//               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-//             );
-//           `);
-//         }
-//         console.log(`Tabla "${table}" creada exitosamente.`);
-//       } else {
-//         console.log(`Tabla "${table}" ya existe.`);
-//       }
-//     }
-//   } catch (error) {
-//     console.error(
-//       "Error durante la inicialización de la base de datos:",
-//       error.message
-//     );
-//     throw error;
-//   }
-// };
-
-// export default initializeDatabase;
 import { turso } from "./db.js";
 
 const initializeDatabase = async () => {
   try {
     console.log("Verificando y creando tablas si no existen...");
 
-    const tables = ["roles", "users", "suppliers"];
+    const tables = ["roles", "users", "suppliers", "materials"];
     for (const table of tables) {
       console.log(`Verificando la existencia de la tabla "${table}"...`);
       const result = await turso.execute(`
@@ -103,6 +42,23 @@ const initializeDatabase = async () => {
               phone TEXT NOT NULL,
               email TEXT UNIQUE NOT NULL,
               created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+          `);
+        } else if (table === "materials") {
+          await turso.execute(`
+            CREATE TABLE materials (
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              name TEXT NOT NULL,
+              description TEXT NOT NULL,
+              isAvailable boolean NOT NULL,
+              cost REAL NOT NULL,
+              date DATE NOT NULL,
+              supplier_id INTEGER NOT NULL,
+              quantity INTEGER NOT NULL,
+              quantityByUnit INTEGER NOT NULL,
+              costByUnit REAL NOT NULL,
+              created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+              FOREIGN KEY (supplier_id) REFERENCES suppliers(id)
             );
           `);
         }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -89,6 +89,8 @@ const router = Router();
  *                   example: Error al hacer login
  */
 
+router.post("/login", login);
+
 /**
  * @swagger
  * /auth/refresh-token:

--- a/src/routes/materials.js
+++ b/src/routes/materials.js
@@ -1,0 +1,414 @@
+import { Router } from "express";
+
+import {
+  createMaterials,
+  getAllMaterials,
+  getMaterialById,
+  updateMaterial,
+  deleteMaterial,
+} from "../controllers/materials/materials.js";
+import { verifyToken } from "../helpers/middleware.js";
+const router = Router();
+
+/**
+ * @swagger
+ * tags:
+ *   name: Materials
+ *   description: Gestión de materiales
+ */
+
+/**
+ * @swagger
+ * /materials:
+ *   post:
+ *     summary: Crear un nuevo material
+ *     description: |
+ *       Este endpoint permite crear un nuevo material en la base de datos.
+ *       Todos los campos son obligatorios.
+ *     tags: [Materials]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Nombre del material.
+ *                 example: Tornillos
+ *               description:
+ *                 type: string
+ *                 description: Descripción del material.
+ *                 example: Tornillos de acero inoxidable
+ *               isAvailable:
+ *                 type: boolean
+ *                 description: Indica si el material está disponible.
+ *                 example: true
+ *               cost:
+ *                 type: number
+ *                 description: Costo total del material.
+ *                 example: 100.50
+ *               date:
+ *                 type: string
+ *                 format: date
+ *                 description: Fecha de adquisición del material.
+ *                 example: "2023-10-01"
+ *               supplier_id:
+ *                 type: integer
+ *                 description: ID del proveedor asociado al material.
+ *                 example: 1
+ *               quantity:
+ *                 type: integer
+ *                 description: Cantidad total del material.
+ *                 example: 100
+ *               quantityByUnit:
+ *                 type: integer
+ *                 description: Cantidad por unidad del material.
+ *                 example: 10
+ *               costByUnit:
+ *                 type: number
+ *                 description: Costo por unidad del material.
+ *                 example: 10.05
+ *             required:
+ *               - name
+ *               - description
+ *               - isAvailable
+ *               - cost
+ *               - date
+ *               - supplier_id
+ *               - quantity
+ *               - quantityByUnit
+ *               - costByUnit
+ *     responses:
+ *       201:
+ *         description: Material creado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Material creado exitosamente
+ *       400:
+ *         description: |
+ *           Error de validación.
+ *           - Si falta algún campo obligatorio.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Todos los campos son obligatorios
+ *       500:
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al crear el material.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al crear el material
+ */
+
+/**
+ * @swagger
+ * /materials:
+ *   get:
+ *     summary: Obtener todos los materiales
+ *     description: |
+ *       Este endpoint retorna una lista de todos los materiales registrados en la base de datos.
+ *     tags: [Materials]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de materiales.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                     example: 1
+ *                   name:
+ *                     type: string
+ *                     example: Tornillos
+ *                   description:
+ *                     type: string
+ *                     example: Tornillos de acero inoxidable
+ *                   isAvailable:
+ *                     type: boolean
+ *                     example: true
+ *                   cost:
+ *                     type: number
+ *                     example: 100.50
+ *                   date:
+ *                     type: string
+ *                     format: date
+ *                     example: "2023-10-01"
+ *                   supplier_id:
+ *                     type: integer
+ *                     example: 1
+ *                   quantity:
+ *                     type: integer
+ *                     example: 100
+ *                   quantityByUnit:
+ *                     type: integer
+ *                     example: 10
+ *                   costByUnit:
+ *                     type: number
+ *                     example: 10.05
+ *                   created_at:
+ *                     type: string
+ *                     format: date-time
+ *                     example: "2023-10-01T12:00:00Z"
+ *       500:
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al obtener los materiales.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al obtener los materiales
+ */
+
+/**
+ * @swagger
+ * /materials/{id}:
+ *   get:
+ *     summary: Obtener un material por ID
+ *     description: |
+ *       Este endpoint permite buscar un material por su ID.
+ *     tags: [Materials]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: ID del material.
+ *         example: 1
+ *     responses:
+ *       200:
+ *         description: Material encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 name:
+ *                   type: string
+ *                   example: Tornillos
+ *                 description:
+ *                   type: string
+ *                   example: Tornillos de acero inoxidable
+ *                 isAvailable:
+ *                   type: boolean
+ *                   example: true
+ *                 cost:
+ *                   type: number
+ *                   example: 100.50
+ *                 date:
+ *                   type: string
+ *                   format: date
+ *                   example: "2023-10-01"
+ *                 supplier_id:
+ *                   type: integer
+ *                   example: 1
+ *                 quantity:
+ *                   type: integer
+ *                   example: 100
+ *                 quantityByUnit:
+ *                   type: integer
+ *                   example: 10
+ *                 costByUnit:
+ *                   type: number
+ *                   example: 10.05
+ *                 created_at:
+ *                   type: string
+ *                   format: date-time
+ *                   example: "2023-10-01T12:00:00Z"
+ *       404:
+ *         description: |
+ *           Material no encontrado.
+ *           - Si no existe un material con el ID proporcionado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Material no encontrado
+ *       500:
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al obtener el material.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al obtener el material
+ */
+
+/**
+ * @swagger
+ * /materials/{id}:
+ *   put:
+ *     summary: Actualizar un material por ID
+ *     description: |
+ *       Este endpoint permite actualizar los datos de un material existente utilizando su ID.
+ *     tags: [Materials]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: ID del material.
+ *         example: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Nuevo nombre del material.
+ *                 example: Tornillos actualizados
+ *               description:
+ *                 type: string
+ *                 description: Nueva descripción del material.
+ *                 example: Tornillos de acero inoxidable de alta calidad
+ *               isAvailable:
+ *                 type: boolean
+ *                 description: Nueva disponibilidad del material.
+ *                 example: false
+ *               cost:
+ *                 type: number
+ *                 description: Nuevo costo total del material.
+ *                 example: 150.75
+ *               date:
+ *                 type: string
+ *                 format: date
+ *                 description: Nueva fecha de adquisición del material.
+ *                 example: "2023-10-05"
+ *               supplier_id:
+ *                 type: integer
+ *                 description: Nuevo ID del proveedor asociado al material.
+ *                 example: 2
+ *               quantity:
+ *                 type: integer
+ *                 description: Nueva cantidad total del material.
+ *                 example: 200
+ *               quantityByUnit:
+ *                 type: integer
+ *                 description: Nueva cantidad por unidad del material.
+ *                 example: 20
+ *               costByUnit:
+ *                 type: number
+ *                 description: Nuevo costo por unidad del material.
+ *                 example: 15.07
+ *     responses:
+ *       200:
+ *         description: Material actualizado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Material actualizado exitosamente
+ *       500:
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al actualizar el material.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al actualizar el material
+ */
+
+/**
+ * @swagger
+ * /materials/{id}:
+ *   delete:
+ *     summary: Eliminar un material por ID
+ *     description: |
+ *       Este endpoint permite eliminar un material de la base de datos utilizando su ID.
+ *     tags: [Materials]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: ID del material.
+ *         example: 1
+ *     responses:
+ *       200:
+ *         description: Material eliminado exitosamente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Material eliminado exitosamente
+ *       500:
+ *         description: |
+ *           Error interno del servidor.
+ *           - Si ocurre un error al eliminar el material.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   example: Error al eliminar el material
+ */
+
+router.post("/", verifyToken, createMaterials);
+router.get("/", verifyToken, getAllMaterials);
+router.get("/:id", verifyToken, getMaterialById);
+router.put("/:id", verifyToken, updateMaterial);
+router.delete("/:id", verifyToken, deleteMaterial);
+
+export { router };


### PR DESCRIPTION
## Descripción
Este PR agrega la gestión de materiales (materials) con operaciones CRUD completas (Crear, Leer, Actualizar, Eliminar) e inicializa la base de datos para soportar esta funcionalidad.

## Cambios principales
1. **Material Management**:
   - Se agregaron endpoints para crear, leer, actualizar y eliminar materiales.
   - Validaciones de campos obligatorios (`name`, `description`, `isAvailable`, `cost`, `date`, `supplier_id`, `quantity`, `quantityByUnit`, `costByUnit`).
   - Se implementaron pruebas unitarias para los nuevos endpoints.

2. **Database Initialization**:
   - Se agregó la tabla `materials` a la base de datos.
   - Se actualizó el script de inicialización de la base de datos.

3. **Mejoras adicionales**:
   - Se corrigieron errores menores en la autenticación.
   - Se actualizó la documentación de Swagger para los nuevos endpoints.

## Cómo probar
1. **Material CRUD**:
   - Usar los siguientes endpoints:
     - `POST /materials` (crear material)
     - `GET /materials` (listar materiales)
     - `GET /materials/{id}` (obtener un material por ID)
     - `PUT /materials/{id}` (actualizar material)
     - `DELETE /materials/{id}` (eliminar material)
   - Verificar que las validaciones funcionen correctamente (campos obligatorios, formato de fecha, etc.).

2. **Database Initialization**:
   - Ejecutar el script de inicialización de la base de datos y verificar que la tabla `materials` se haya creado correctamente.

3. **Documentación**:
   - Revisar la documentación de Swagger en `/api-docs` para asegurarse de que los nuevos endpoints estén correctamente documentados.

## Notas adicionales
- Este PR depende de la rama `material`.
- Se recomienda revisar los cambios en conjunto con el equipo de backend y frontend para asegurar la compatibilidad.